### PR TITLE
Ensure clean UPS state in setup script

### DIFF
--- a/setup_numiana.sh
+++ b/setup_numiana.sh
@@ -7,6 +7,9 @@ if [[ -f "$COMMON_SETUPS" ]]; then
 else
   printf 'setup_numiana.sh: warning: missing common UPS setups: %s\n' "$COMMON_SETUPS" >&2
 fi
+
+# Ensure a clean UPS state (avoid container’s preloaded site stack)
+type unsetup &>/dev/null && unsetup -a || true
 CFG="${NUMIANA_CONFIG:-$(dirname "${BASH_SOURCE[0]}")/config_numiana.sh}"
 [[ -f "$CFG" ]] && source "$CFG"
 have_cmd() { command -v "$1" >/dev/null 2>&1; }


### PR DESCRIPTION
## Summary
- ensure setup_numiana.sh resets any preloaded UPS state before running

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132ffe3c58832e8241aa7b4964c8e2)