### PR TITLE
Use unsetup_all helper when clearing UPS state

### DIFF
--- a/setup_numiana.sh
+++ b/setup_numiana.sh
@@ -9,7 +9,7 @@ else
 fi
 
 # Ensure a clean UPS state (avoid container’s preloaded site stack)
-type unsetup &>/dev/null && unsetup -a || true
+type unsetup_all &>/dev/null && unsetup_all || true
 CFG="${NUMIANA_CONFIG:-$(dirname "${BASH_SOURCE[0]}")/config_numiana.sh}"
 [[ -f "$CFG" ]] && source "$CFG"
 have_cmd() { command -v "$1" >/dev/null 2>&1; }


### PR DESCRIPTION
## Summary
- replace the invalid `unsetup -a` invocation with `unsetup_all`
- rely on the UPS helper that safely clears the environment when available

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134960b6f8832ebfef520af668fd1a)