### PR TITLE
Default dev container and UPS bootstrapping

### DIFF
--- a/setup_numiana.sh
+++ b/setup_numiana.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
-# Minimal UPS bootstrap (no site auto-setup)
-COMMON_SETUPS=/cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
-if [[ -f "$COMMON_SETUPS" ]]; then
-  source "$COMMON_SETUPS"
-  export PRODUCTS=/cvmfs/larsoft.opensciencegrid.org/products:/cvmfs/uboone.opensciencegrid.org/products:${PRODUCTS:-}
-else
-  printf 'setup_numiana.sh: warning: missing common UPS setups: %s\n' "$COMMON_SETUPS" >&2
-fi
+source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setup
+source /cvmfs/larsoft.opensciencegrid.org/products/setup
+source /cvmfs/uboone.opensciencegrid.org/products/setup
 
-# Avoid touching any preloaded UPS state; callers should start from a clean shell
 CFG="${NUMIANA_CONFIG:-$(dirname "${BASH_SOURCE[0]}")/config_numiana.sh}"
 [[ -f "$CFG" ]] && source "$CFG"
 have_cmd() { command -v "$1" >/dev/null 2>&1; }

--- a/shell_apptainer.sh
+++ b/shell_apptainer.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-exec /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh "$@"
+if [[ $# -eq 0 ]]; then
+  exec /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh -d
+else
+  exec /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh "$@"
+fi


### PR DESCRIPTION
## Summary
- default the shell_apptainer wrapper to the Fermilab dev container when invoked without arguments
- source the UPS setup scripts directly to avoid site-specific preloads when bootstrapping numiana

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691354252e60832e8ed8bdfd57c7bc9f)