### PR TITLE
Refine build script error handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-#set -e
-cd "$(dirname "$0")"
-#source ./setup_numiana.sh
-if ! command -v root-config >/dev/null 2>&1; then
-  echo "build.sh: error: root-config not found; ensure ROOT is set up." >&2
-  exit 1
-fi
-make "${1:-all}"
+build_numiana() {
+  cd "$(dirname "${BASH_SOURCE[0]}")" || {
+    echo "build.sh: error: could not cd to script directory." >&2
+    return 1
+  }
+  if ! command -v root-config >/dev/null 2>&1; then
+    echo "build.sh: error: root-config not found; ensure ROOT is set up." >&2
+    return 1
+  fi
+  make "${1:-all}"
+}
+build_numiana "$@"


### PR DESCRIPTION
## Summary
- wrap build steps in a function to allow sourcing without exiting the shell
- ensure the script changes directory safely before running make
- retain root-config presence check and default to the all target

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69189882b430832ebee5c7ec09baa599)