### PR TITLE
Adjust DK2NU includes to use PPFX_INC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 INCLUDES = -I$(shell root-config --incdir) -I$(NUMIANA_INC)
-DK2NU_INCLUDES = -I$(PPFX_DIR)/include -I$(shell root-config --incdir) -I$(BOOSTROOT) -I${DK2NU}/include -I$(NUMIANA_INC)
+DK2NU_INCLUDES = -I$(PPFX_INC) -I$(PPFX_INC)/include \
+                 -I$(shell root-config --incdir) \
+                 -I$(BOOSTROOT) -I${DK2NU}/include -I$(NUMIANA_INC)
 DEPLIBS=$(shell root-config --libs)
 
 CC	=	g++


### PR DESCRIPTION
## Summary
- update the DK2NU include path definition to use the PPFX_INC variable and include its include directory

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691899f2131c832e9357ddac07c8f27a)