### PR TITLE
Update mu-flux integration macro

### DIFF
--- a/examples/integrate_flux.C
+++ b/examples/integrate_flux.C
@@ -1,0 +1,20 @@
+#include <ROOT/RDataFrame.hxx>
+#include <TChain.h>
+using namespace ROOT;
+using namespace ROOT::RDF;
+
+void integrate_mu_flux(std::string pattern, double Emin=0.25, double Emax=5.0, int nthreads=1, bool use_ppfx_cv=true) {
+  if (nthreads>1) ROOT::EnableImplicitMT(nthreads);
+  TChain ch("outTree"); ch.Add(pattern.c_str());
+  RDataFrame df(ch);
+  auto sel = [Emin,Emax](int t, float E){ return (t==14 || t==-14) && E>=Emin && E<Emax; };
+  auto d0  = df.Filter(sel, {"ntype","nuE"});
+  auto d   = use_ppfx_cv ? d0.Define("w", [](float a,float b){ return (double)a*(double)b; }, {"wgt","wgt_ppfx"})
+                         : d0.Define("w", [](float a){ return (double)a; }, {"wgt"});
+  auto sum = d.Sum<double>("w");
+  auto s14 = d.Filter([](int t){return t==14;},{"ntype"}).Sum<double>("w");
+  auto s14b= d.Filter([](int t){return t==-14;},{"ntype"}).Sum<double>("w");
+  std::cout.setf(std::ios::scientific); std::cout.precision(6);
+  std::cout<<"E=["<<Emin<<","<<Emax<<"] GeV, per-POT mu-flavour integrated flux"<<(use_ppfx_cv?" (CV)":" (raw)")<<": "<<*sum<<" nu/cm^2/POT\\n";
+  std::cout<<"  numu: "<<*s14<<"  numubar: "<<*s14b<<"\\n";
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,11 @@
+# FHC
+python scripts/make_flux_ntuple.py FHC
+
+# RHC
+python scripts/make_flux_ntuple.py RHC
+
+# FHC (per-POT, μ-flavour only, 0.25–5 GeV)
+root -l -q 'integrate_mu_flux.C("fhc_numi_g4104_ppfx.root",0.25,5.0,8,true)'
+
+# RHC
+root -l -q 'integrate_mu_flux.C("rhc_numi_g4104_ppfx.root",0.25,5.0,8,true)'

--- a/scripts/make_flux_ntuple.py
+++ b/scripts/make_flux_ntuple.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import os
+import sys
+import ROOT
+
+ROOT.gROOT.SetBatch(True)
+
+if ROOT.gSystem.Load(os.path.join(os.path.dirname(__file__), "..", "lib", "Dk2NuFlux_cc.so")) != 0:
+    if ROOT.gSystem.Load("libDk2NuFlux_cc.so") != 0:
+        sys.exit("ERROR: could not load Dk2NuFlux_cc.so. Did you run './build.sh dk2nu'?")
+
+
+def default_pattern(mode: str) -> str:
+    if mode.upper() == "FHC":
+        base = os.environ.get(
+            "DK2NU_FHC_DIR",
+            "/pnfs/uboone/persistent/users/bnayak/flux_files/uboone_beamsim_g4.10.4_nothresh/me000z200i/run0/files"
+        )
+        return os.path.join(base, "g4numi_minervame_me000z200i_*.root")
+    else:
+        base = os.environ.get(
+            "DK2NU_RHC_DIR",
+            "/pnfs/uboone/persistent/users/bnayak/flux_files/uboone_beamsim_g4.10.4_nothresh/me000z-200i/run0/files"
+        )
+        return os.path.join(base, "g4numi_minervame_me000z-200i_*.root")
+
+
+def main():
+    mode = (sys.argv[1] if len(sys.argv) > 1 else "FHC").upper()
+    inpat = sys.argv[2] if len(sys.argv) > 2 else default_pattern(mode)
+    out = sys.argv[3] if len(sys.argv) > 3 else f"outputs/ubnumi_g4104_nothresh_{mode}.root"
+
+    os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
+    print(f"[make_flux_ntuple] mode={mode}\n  in : {inpat}\n  out: {out}")
+    ROOT.Dk2NuFlux(inpat, out).CalculateFlux()
+    print("[make_flux_ntuple] done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the ROOT macro with a muon-flavour focused integrate_mu_flux helper using RDF utilities
- refresh the scripts README with the new integrate_mu_flux usage examples for FHC and RHC flux files

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ad87a2c8832e9711d5f646dfc55b)