### PR TITLE
Replace TIter usage in integrate flux script

### DIFF
--- a/scripts/integrate_flux_perpot.C
+++ b/scripts/integrate_flux_perpot.C
@@ -2,7 +2,7 @@
 #include "TFile.h"
 #include "TH1D.h"
 #include "TChainElement.h"
-#include "TIter.h"
+#include "TObjArray.h"
 #include <iostream>
 
 // root -l -b -q 'scripts/integrate_flux_perpot.C("/exp/uboone/data/users/bnayak/ppfx/flugg_studies/comparisons/dk2nu_fhc_ppfx_g4_10_4.root","FHC",0.25,5.0)'
@@ -31,13 +31,16 @@ void integrate_flux_perpot(const char* inpat,
   // total POT in these inputs (for reference; result below is already per POT)
   double totPOT = 0.0;
 
-  auto* files = ch.GetListOfFiles();
-  TIter next(files);
-  while (auto* el = static_cast<TChainElement*>(next())) {
-    TFile f(el->GetTitle(), "READ");
-    if (!f.IsOpen()) continue;
-    if (auto* hp = dynamic_cast<TH1*>(f.Get("POT"))) {
-      totPOT += hp->Integral();
+  if (auto* files = ch.GetListOfFiles()) {
+    const Int_t nfiles = files->GetEntriesFast();
+    for (Int_t i = 0; i < nfiles; ++i) {
+      auto* el = static_cast<TChainElement*>(files->UncheckedAt(i));
+      if (!el) continue;
+      TFile f(el->GetTitle(), "READ");
+      if (!f.IsOpen()) continue;
+      if (auto* hp = dynamic_cast<TH1*>(f.Get("POT"))) {
+        totPOT += hp->Integral();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the `TIter` dependency in `integrate_flux_perpot.C` with direct `TObjArray` iteration to avoid missing headers
- guard file iteration and continue accumulating POT only for open files

## Testing
- not run (manual)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918cbbe2c04832eb4662389e9a9d384)