### PR TITLE
Improve minimal flux plotting macro

### DIFF
--- a/scripts/plot_flux_minimal.C
+++ b/scripts/plot_flux_minimal.C
@@ -14,6 +14,8 @@
 #include <iostream>
 #include <string>
 #include <cstdio>
+#include <cmath>
+#include <limits>
 
 void plot_flux_minimal() {
   // ---------------- hardcoded choices ----------------
@@ -21,25 +23,29 @@ void plot_flux_minimal() {
   const char* RHC_FILE = "/exp/uboone/data/users/bnayak/ppfx/flugg_studies/comparisons/dk2nu_rhc_ppfx_g4_10_4.root";
 
   const double Emin = 0.0;
-  const double Emax = 10.0;     // extend to 8 GeV if you like (bins stay 10 MeV)
-  const double ymin = 1e-12;     // y-axis clip
-  const double ymax = 1e-3;
+  const double Emax = 10.0;
+
+  // We want 25 MeV/bin:
+  const double dE = 0.025;                  // GeV  (25 MeV)
+
+  // fallback y-range (will be overridden by auto scaling below)
+  const double ymin_fallback = 1e-8;
+  const double ymax_fallback = 1e+6;
 
   const char* OUT_FHC = "uboone_flux_FHC.pdf";
   const char* OUT_RHC = "uboone_flux_RHC.pdf";
 
-  // Normalization toggle: per POT (true) or scaled to 6e20 POT (false)
-  constexpr bool NORM_PER_POT = true;
-  constexpr double NOMINAL_POT = 6e20;
+  // ---- Normalization ----
+  // We want 6×10^20 POT units:
+  constexpr bool   NORM_PER_POT = false;    // false => scale to NOMINAL_POT
+  constexpr double NOMINAL_POT  = 6e20;
   // ---------------------------------------------------
 
   gStyle->SetOptStat(0);
-  TH1::AddDirectory(kTRUE);         // let TTree::Draw find our histograms
+  TH1::AddDirectory(kTRUE);
 
-  const double dE = 0.01;           // 10 MeV/bin
   const int nbins = std::max(1, int((Emax - Emin)/dE + 0.5));
 
-  // helper: delete stale hist with same name (avoids "Potential memory leak" warning)
   auto fresh = [&](const char* name) {
     if (auto* old = dynamic_cast<TH1D*>(gROOT->FindObject(name))) delete old;
     TH1D* h = new TH1D(name, "", nbins, Emin, Emax);
@@ -68,6 +74,22 @@ void plot_flux_minimal() {
     h->SetMarkerSize(0);
   };
 
+  auto set_logy_limits = [&](TH1* frame, std::initializer_list<TH1*> hs){
+    double minpos = std::numeric_limits<double>::infinity();
+    double maxval = 0.0;
+    for (TH1* h : hs) {
+      for (int b=1; b<=h->GetNbinsX(); ++b) {
+        double y = h->GetBinContent(b);
+        if (y>0.0 && y<minpos) minpos = y;
+        if (y>maxval)          maxval = y;
+      }
+    }
+    if (!std::isfinite(minpos)) minpos = ymin_fallback;
+    if (maxval<=0.0)            maxval = ymax_fallback;
+    frame->SetMinimum(std::max(1e-30, minpos*0.8));   // must be >0 for log
+    frame->SetMaximum(maxval*5.0);
+  };
+
   auto make_and_draw = [&](const char* file, const char* tag, const char* outname){
     // ----- build spectra -----
     TChain ch("outTree"); ch.Add(file);
@@ -75,20 +97,24 @@ void plot_flux_minimal() {
     const bool has_wgt  = ch.GetListOfBranches()->FindObject("wgt");
     const bool has_ppfx = ch.GetListOfBranches()->FindObject("wgt_ppfx");
 
-    // (1) Combine geometry/acceptance with PPFX CV
-    std::string wexpr = has_wgt ? "wgt" : "1";
-    if (has_ppfx) wexpr += "*wgt_ppfx";
+    // CV weight: geometry/acceptance * PPFX CV (if present)
+    TString w = has_wgt ? "wgt" : "1";
+    if (has_ppfx) w += "*wgt_ppfx";
 
-    // (2) Scale by POT to match the axis label (per POT) or to 6e20 POT
+    // POT scaling
     const double pot_total = sumPOT(ch);
     if (pot_total <= 0) {
       std::cerr << "[plot_flux_minimal] WARNING: total POT <= 0; proceeding without POT scaling.\n";
     }
     char w_scaled[256];
-    if (NORM_PER_POT) {
-      std::snprintf(w_scaled, sizeof(w_scaled), "(%s)/(%g)", wexpr.c_str(), std::max(1e-30, pot_total));
+    if (pot_total > 0) {
+      if (NORM_PER_POT) {
+        std::snprintf(w_scaled, sizeof(w_scaled), "(%s)/(%g)", w.Data(), pot_total);
+      } else {
+        std::snprintf(w_scaled, sizeof(w_scaled), "(%s)*(%g)", w.Data(), NOMINAL_POT / pot_total);
+      }
     } else {
-      std::snprintf(w_scaled, sizeof(w_scaled), "(%s)*(%g)", wexpr.c_str(), NOMINAL_POT / std::max(1e-30, pot_total));
+      std::snprintf(w_scaled, sizeof(w_scaled), "%s", w.Data());
     }
 
     TH1D* h_numu  = fresh(Form("h_numu_%s",  tag));
@@ -98,7 +124,7 @@ void plot_flux_minimal() {
 
     auto fill = [&](TH1D* h, int pdg){
       ch.Draw(Form("nuE>>%s", h->GetName()),
-              Form("(%g<=nuE && nuE<%g) * (ntype==%d) * %s", Emin, Emax, pdg, w_scaled),
+              Form("(%g<=nuE && nuE<%g) * (ntype==%d) * (%s)", Emin, Emax, pdg, w_scaled),
               "goff");
     };
     fill(h_numu,  14);
@@ -118,16 +144,12 @@ void plot_flux_minimal() {
     TH1D* frame = (TH1D*)h_numu->Clone(Form("frame_%s",tag));
     frame->Reset("ICES");
     frame->GetXaxis()->SetTitle("Neutrino Energy [GeV]");
-    frame->GetYaxis()->SetTitle(NORM_PER_POT ?
-      "#nu / POT / 10 MeV / cm^{2}" :
-      "#nu / 6e20 POT / 10 MeV / cm^{2}");
-    frame->GetXaxis()->SetTitleSize(0.05);
-    frame->GetXaxis()->SetLabelSize(0.045);
-    frame->GetYaxis()->SetTitleSize(0.055);
-    frame->GetYaxis()->SetLabelSize(0.045);
-    frame->GetYaxis()->SetTitleOffset(1.35);
-    frame->SetMinimum(ymin);
-    frame->SetMaximum(ymax);
+
+    // Axis label that exactly matches the bin width and 6e20 scaling:
+    const double dE_MeV = dE * 1000.0;
+    frame->GetYaxis()->SetTitle(Form("#nu / 6#times10^{20} POT / %.0f MeV / cm^{2}", dE_MeV));
+
+    set_logy_limits(frame, {h_numu, h_anumu, h_nue, h_anue});
     frame->Draw("AXIS");
 
     h_numu ->Draw("HIST SAME");
@@ -155,16 +177,20 @@ void plot_flux_minimal() {
     t.SetTextSize(0.05); t.SetTextColor(kGray+2);
     t.DrawLatex(0.16, 0.90, Form("%s Mode", tag));
     t.SetTextSize(0.035); t.SetTextColor(kGray+1);
-    t.DrawLatex(0.16, 0.84, Form("POT in inputs: %.3g", pot_total));
+    t.DrawLatex(0.16, 0.84, Form("POT in inputs: %.3g", std::max(0.0, sumPOT(ch))));
+
+    // small printout to confirm bin width actually used
+    std::cout << "[plot_flux_minimal] " << tag
+              << ": bin width = " << h_numu->GetBinWidth(1) << " GeV ("
+              << h_numu->GetBinWidth(1)*1000.0 << " MeV), "
+              << (NORM_PER_POT ? "per-POT" : "scaled to 6e20 POT") << "\n";
 
     c.SaveAs(outname);
 
-    // cleanup
     delete frame;
     delete h_numu; delete h_anumu; delete h_nue; delete h_anue;
   };
 
-  // Make the two separate plots
   make_and_draw(FHC_FILE, "FHC", OUT_FHC);
   make_and_draw(RHC_FILE, "RHC", OUT_RHC);
 


### PR DESCRIPTION
## Summary
- switch the minimal flux macro to 25 MeV binning with automatic log-axis scaling and an updated y-axis label
- ensure POT scaling is tied to the desired 6×10^20 POT normalization and report the binning used in the console output
- add a dynamic y-range finder so the produced plots stay readable regardless of the input spectra

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e8ade674832e951eca3501be94d3)