### PR TITLE
Fix ROOT macro overload ambiguity

### DIFF
--- a/scripts/flux_fig_B_EvTheta_individual.C
+++ b/scripts/flux_fig_B_EvTheta_individual.C
@@ -201,8 +201,8 @@ static void draw_one_plot(const char* mode,
 }
 
 // ------------------------------ Driver --------------------------------------
-void flux_fig_B_EvTheta_individual(const char* fhc_file = CFG::FILE_FHC,
-                                   const char* rhc_file = CFG::FILE_RHC)
+void flux_fig_B_EvTheta_individual(const char* fhc_file,
+                                   const char* rhc_file)
 {
   set_minimal_white_style();
 


### PR DESCRIPTION
## Summary
- remove the default arguments from the main `flux_fig_B_EvTheta_individual` driver
- keep the convenience wrapper that forwards the default file paths so zero-arg usage remains available

## Testing
- not run (ROOT is not available in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919f6c38af8832ebf9074213da9b8be)