### PR TITLE
Refine legend percentages and total flux color

### DIFF
--- a/scripts/uboone_numu_parentE_angleStyle.C
+++ b/scripts/uboone_numu_parentE_angleStyle.C
@@ -112,7 +112,7 @@ static TLegend* build_legend_like_stacked(TPad* p_leg,
   double s_tot=0.0; for(double s:sums) s_tot+=s;
   for(size_t i=0;i<items.size();++i){
     TString lab=items[i].second;
-    if(show_pct && s_tot>0 && i<sums.size()) lab = Form("%s (%.1f%%)", lab.Data(), 100.0*sums[i]/s_tot);
+    if(show_pct && s_tot>0 && i<sums.size()) lab = Form("%s (%.2f%%)", lab.Data(), 100.0*sums[i]/s_tot);
     L->AddEntry(items[i].first, lab, "l");
   }
   return L;
@@ -180,7 +180,7 @@ static void draw_numu_parent_energy(const char* mode, TFile& f){
   int C_muP = TColor::GetColor("#7c4dff"); // vivid violet
   int C_muM = TColor::GetColor("#aa00ff"); // vivid magenta
   int C_KL  = TColor::GetColor("#00e5ff"); // bright cyan
-  int C_tot = TColor::GetColor("#111111"); // near-black for total
+  int C_tot = TColor::GetColor("#616161"); // dark gray for total (not black)
 
   style_line(h_piP, C_piP, 1);
   style_line(h_piM, C_piM, 1);


### PR DESCRIPTION
## Summary
- show parent contributions in the legend with two decimal places of precision
- change the total flux line color from near-black to dark gray so it is less harsh on light backgrounds

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2223a178832e87032a4c37a17c2f)